### PR TITLE
Fix Index of out bounds by applying fix from original Java

### DIFF
--- a/MP3Sharp/Decoding/Decoders/LayerIIIDecoder.cs
+++ b/MP3Sharp/Decoding/Decoders/LayerIIIDecoder.cs
@@ -1174,10 +1174,31 @@ namespace MP3Sharp.Decoding.Decoders
                 else
                 {
                     int abv = is_1d[j];
-                    if (is_1d[j] > 0)
-                        xr_1d[quotien][reste] = g_gain*t_43[abv];
+                    // Pow Array fix (11/17/04)
+                    double d43 = (4.0 / 3.0);
+                    if (abv < t_43.Length)
+                    {
+                        if (is_1d[j] > 0)
+                        {
+                            xr_1d[quotien][reste] = g_gain * t_43[abv];
+                        }
+                        else if (-abv < t_43.Length)
+                        {
+                            xr_1d[quotien][reste] = -g_gain * t_43[-abv];
+                        }
+                        else
+                        {
+                            xr_1d[quotien][reste] = -g_gain * (float)Math.Pow(-abv, d43);
+                        }
+                    }
+                    else if (is_1d[j] > 0)
+                    {
+                        xr_1d[quotien][reste] = g_gain * (float)Math.Pow(abv, d43);
+                    }
                     else
-                        xr_1d[quotien][reste] = -g_gain*t_43[-abv];
+                    {
+                        xr_1d[quotien][reste] = -g_gain * (float)Math.Pow(-abv, d43);
+                    }
                 }
             }
 


### PR DESCRIPTION
I was getting an index out of bounds error for an MP3, and found a fix had been applied in the Java source where the crash was happening.  I've applied that fix, and the MP3 plays well now.

[Original source](https://github.com/libgdx/jlayer-gdx/blob/master/src/javazoom/jl/decoder/LayerIIIDecoder.java) search for `// Pow Array fix (11/17/04)`