### PR TITLE
Make MP3Stream use a mono buffer for single-channel mp3 streams

### DIFF
--- a/MP3Sharp/Decoding/ABuffer.cs
+++ b/MP3Sharp/Decoding/ABuffer.cs
@@ -16,29 +16,54 @@
 namespace MP3Sharp.Decoding
 {
     /// <summary>
-    ///     Base Class for audio output.
+    /// A buffer that a <see cref="Decoder"/> can output to.
     /// </summary>
-    internal abstract class ABuffer
+    internal interface ABuffer
     {
-        public const int OBUFFERSIZE = 2*1152; // max. 2 * 1152 samples per frame
-        public const int MAXCHANNELS = 2; // max. number of channels
-
         /// <summary>
         ///     Takes a 16 Bit PCM sample.
         /// </summary>
-        public abstract void Append(int channel, short valueRenamed);
+        void Append(int channel, short valueRenamed);
 
         /// <summary>
         ///     Accepts 32 new PCM samples.
         /// </summary>
-        public virtual void AppendSamples(int channel, float[] f)
+        void AppendSamples(int channel, float[] f);
+        
+        /// <summary>
+        ///     Write the samples to the file or directly to the audio hardware.
+        /// </summary>
+        void WriteBuffer(int val);
+
+        void Close();
+
+        /// <summary>
+        ///     Clears all data in the buffer (for seeking).
+        /// </summary>
+        void ClearBuffer();
+
+        /// <summary>
+        ///     Notify the buffer that the user has stopped the stream.
+        /// </summary>
+        void SetStopFlag();
+    }
+    
+    internal static class ABufferUtil
+    {
+        public const int OBUFFERSIZE = 2*1152; // max. 2 * 1152 samples per frame
+        public const int MAXCHANNELS = 2; // max. number of channels
+        
+        /// <summary>
+        ///     Accepts 32 new PCM samples.
+        /// </summary>
+        internal static void DefaultAppendSamples(this ABuffer buffer, int channel, float[] f)
         {
             for (int i = 0; i < 32; i++)
             {
-                Append(channel, Clip((f[i])));
+                buffer.Append(channel, Clip((f[i])));
             }
         }
-
+        
         /// <summary>
         ///     Clip Sample to 16 Bits
         /// </summary>
@@ -46,22 +71,5 @@ namespace MP3Sharp.Decoding
         {
             return ((sample > 32767.0f) ? (short) 32767 : ((sample < -32768.0f) ? (short) -32768 : (short) sample));
         }
-
-        /// <summary>
-        ///     Write the samples to the file or directly to the audio hardware.
-        /// </summary>
-        public abstract void WriteBuffer(int val);
-
-        public abstract void Close();
-
-        /// <summary>
-        ///     Clears all data in the buffer (for seeking).
-        /// </summary>
-        public abstract void ClearBuffer();
-
-        /// <summary>
-        ///     Notify the buffer that the user has stopped the stream.
-        /// </summary>
-        public abstract void SetStopFlag();
     }
 }

--- a/MP3Sharp/Decoding/Decoder.cs
+++ b/MP3Sharp/Decoding/Decoder.cs
@@ -118,7 +118,7 @@ namespace MP3Sharp.Decoding
         ///     an upper bound and fewer samples may actually be written, depending
         ///     upon the sample rate and number of channels.
         /// </summary>
-        public virtual int OutputBlockSize => ABuffer.OBUFFERSIZE;
+        public virtual int OutputBlockSize => ABufferUtil.OBUFFERSIZE;
 
         private void InitBlock()
         {

--- a/MP3Sharp/Decoding/SampleBuffer.cs
+++ b/MP3Sharp/Decoding/SampleBuffer.cs
@@ -31,8 +31,8 @@ namespace MP3Sharp.Decoding
         /// </summary>
         public SampleBuffer(int sample_frequency, int number_of_channels)
         {
-            buffer = new short[OBUFFERSIZE];
-            bufferp = new int[MAXCHANNELS];
+            buffer = new short[ABufferUtil.OBUFFERSIZE];
+            bufferp = new int[ABufferUtil.MAXCHANNELS];
             channels = number_of_channels;
             frequency = sample_frequency;
 
@@ -51,13 +51,13 @@ namespace MP3Sharp.Decoding
         /// <summary>
         ///     Takes a 16 Bit PCM sample.
         /// </summary>
-        public override void Append(int channel, short valueRenamed)
+        public void Append(int channel, short valueRenamed)
         {
             buffer[bufferp[channel]] = valueRenamed;
             bufferp[channel] += channels;
         }
 
-        public override void AppendSamples(int channel, float[] f)
+        public void AppendSamples(int channel, float[] f)
         {
             int pos = bufferp[channel];
 
@@ -80,20 +80,20 @@ namespace MP3Sharp.Decoding
         /// <summary>
         ///     Write the samples to the file (Random Acces).
         /// </summary>
-        public override void WriteBuffer(int val)
+        public void WriteBuffer(int val)
         {
             //for (int i = 0; i < channels; ++i) 
             //	bufferp[i] = (short)i;
         }
 
-        public override void Close()
+        public void Close()
         {
         }
 
         /// <summary>
         ///     *
         /// </summary>
-        public override void ClearBuffer()
+        public void ClearBuffer()
         {
             for (int i = 0; i < channels; ++i)
                 bufferp[i] = (short) i;
@@ -102,7 +102,7 @@ namespace MP3Sharp.Decoding
         /// <summary>
         ///     *
         /// </summary>
-        public override void SetStopFlag()
+        public void SetStopFlag()
         {
 
         }

--- a/MP3Sharp/IO/WaveFileBuffer.cs
+++ b/MP3Sharp/IO/WaveFileBuffer.cs
@@ -33,8 +33,8 @@ namespace MP3Sharp.IO
             if (fileName == null)
                 throw new NullReferenceException("FileName");
 
-            m_Buffer = new short[OBUFFERSIZE];
-            m_Bufferp = new short[MAXCHANNELS];
+            m_Buffer = new short[ABufferUtil.OBUFFERSIZE];
+            m_Bufferp = new short[ABufferUtil.MAXCHANNELS];
             m_Channels = numberOfChannels;
 
             for (int i = 0; i < numberOfChannels; ++i)
@@ -47,8 +47,8 @@ namespace MP3Sharp.IO
 
         public WaveFileBuffer(int numberOfChannels, int freq, Stream stream)
         {
-            m_Buffer = new short[OBUFFERSIZE];
-            m_Bufferp = new short[MAXCHANNELS];
+            m_Buffer = new short[ABufferUtil.OBUFFERSIZE];
+            m_Bufferp = new short[ABufferUtil.MAXCHANNELS];
             m_Channels = numberOfChannels;
 
             for (int i = 0; i < numberOfChannels; ++i)
@@ -62,13 +62,18 @@ namespace MP3Sharp.IO
         /// <summary>
         ///     Takes a 16 Bit PCM sample.
         /// </summary>
-        public override void Append(int channel, short valueRenamed)
+        public void Append(int channel, short valueRenamed)
         {
             m_Buffer[m_Bufferp[channel]] = valueRenamed;
             m_Bufferp[channel] = (short) (m_Bufferp[channel] + m_Channels);
         }
 
-        public override void WriteBuffer(int val)
+        public void AppendSamples(int channel, float[] f)
+        {
+            this.DefaultAppendSamples(channel, f);
+        }
+
+        public void WriteBuffer(int val)
         {
             int rc = m_OutWave.WriteData(m_Buffer, m_Bufferp[0]);
             for (int i = 0; i < m_Channels; ++i)
@@ -80,7 +85,7 @@ namespace MP3Sharp.IO
             m_OutWave.Close(justWriteLengthBytes);
         }
 
-        public override void Close()
+        public void Close()
         {
             m_OutWave.Close();
         }
@@ -88,14 +93,14 @@ namespace MP3Sharp.IO
         /// <summary>
         ///     *
         /// </summary>
-        public override void ClearBuffer()
+        public void ClearBuffer()
         {
         }
 
         /// <summary>
         ///     *
         /// </summary>
-        public override void SetStopFlag()
+        public void SetStopFlag()
         {
         }
     }

--- a/MP3Sharp/IStreamBuffer.cs
+++ b/MP3Sharp/IStreamBuffer.cs
@@ -1,0 +1,23 @@
+﻿using MP3Sharp.Decoding;
+
+namespace MP3Sharp
+{
+    /// <summary>
+    /// An <see cref="ABuffer"/> suitable for being used by an <see cref="MP3Stream"/> for buffering output from its decoder.
+    /// </summary>
+    internal interface IStreamBuffer : ABuffer
+    {
+        int BytesLeft { get; }
+
+        /// <summary>
+        ///     Reads a sequence of bytes from the buffer and advances the position of the 
+        ///     buffer by the number of bytes read.
+        /// </summary>
+        /// <returns>
+        ///     The total number of bytes read in to the buffer. This can be less than the
+        ///     number of bytes requested if that many bytes are not currently available, or
+        ///     zero if th eend of the buffer has been reached.
+        /// </returns>
+        int Read(byte[] bufferOut, int offset, int count);
+    }
+}

--- a/MP3Sharp/MP3Stream.cs
+++ b/MP3Sharp/MP3Stream.cs
@@ -92,7 +92,8 @@ namespace MP3Sharp
                 {
                     m_ChannelCountRep = 1;
                     m_Buffer = new Buffer16BitMono();
-                } else 
+                } 
+                else 
                 {
                     m_ChannelCountRep = 2;
                     m_Buffer = new Buffer16BitStereo();


### PR DESCRIPTION
Notes:
* Refactors ABuffer into an interface instead of an abstract class, which makes it easier to use the same buffer instance for both the decoder and the stream.